### PR TITLE
The last line in the REPL is half cut off

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -72,6 +72,7 @@ body.loaded {
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    box-sizing: content-box;
 }
 
 #terminal-tabs {


### PR DESCRIPTION
This appears to be due to the interplay of the padding on the #xterm element and the box-sizing of the #terminal-container element being set to border-box. This issue in the xterm.js repository talks about the same thing: xtermjs/xterm.js#1283

The workaround mentioned in the issue appears to solve the problem here. That is, set the box-sizing on the #terminal-container to be content-box.

Before: 
![before_change](https://github.com/user-attachments/assets/b4fa8e73-267c-431b-89c6-fbd12ced0dd9)

After:
![after_change](https://github.com/user-attachments/assets/ecf01c5e-61bc-4b3e-bc18-f8a88563714c)