### PR TITLE
Fix copy/paste, etc. problem I created with 078312a

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1050,6 +1050,8 @@ export function applyTranslation() {
         if (ev.ctrlKey || ev.metaKey) {
             if (ev.code == 'KeyS') {
                 saveCurrentFile()
+            } else {
+                return
             }
         } else if (ev.code == 'F5') {
             runCurrentFile()


### PR DESCRIPTION
Sorry, in the prior commit, if the ctrl/meta key was pressed with something _other_ than s, we ended up preventing that default action. So copy/paste wouldn't work, for example. My bad. I was trying to reorganize the if/else logic a bit to make room for future ctrl+<key> shortcuts without needing to repeat the `ev.ctrl || ev.metaKey` clause for each. Perhaps it's not necessary.

Let me know if you'd prefer a pull with the older if/else structure instead.