### PR TITLE
Feature/unicode file

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -155,7 +155,7 @@ async function prepareNewPort(type) {
             toastr.error('WebSerial is not available on iOS')
             return
         }
-        if (window.location.protocol === 'http:') {
+        if (window.location.protocol === 'http:' && !window.location.hostname.includes('localhost')) {
             toastr.error('WebSerial cannot be accessed with unsecure connection')
             return
         }

--- a/src/rawmode.js
+++ b/src/rawmode.js
@@ -249,11 +249,14 @@ def walk(p):
   fn=p+'/'+n
   try: s=os.stat(fn)
   except: s=(0,)*7
-  if s[0] & 0x4000 == 0:
-   print('f|'+fn+'|'+str(s[6]))
-  elif n not in ('.','..'):
-   print('d|'+fn+'|'+str(s[6]))
-   walk(fn)
+  try:
+   if s[0] & 0x4000 == 0:
+      print('f|'+fn+'|'+str(s[6]))
+   elif n not in ('.','..'):
+      print('d|'+fn+'|'+str(s[6]))
+      walk(fn)
+  except: pass
+  
 walk('')
 `)
 


### PR DESCRIPTION
This adds two things
- Allow for connection to serial devices on localhost
- Add an `except` when trying to parse the filesystem because it errors on unicode files.

One thing I'd like is to change the Python script to Node.JS so I can more easily host it on Vercel.