### PR TITLE
Fix file changed indicator not going away

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1210,6 +1210,7 @@ export function applyTranslation() {
         const fileElement = QS(`#menu-file-tree [data-fn="${event.detail.fn}"]`)
         if (fileElement) {
             fileElement.classList.remove("open")
+            fileElement.classList.remove("changed")
         }
     })
 


### PR DESCRIPTION
As pointed out by @ma261065  in [pull36](https://github.com/vshymanskyy/ViperIDE/pull/36), the file changed indicator in the file tree incorrectly stays around after a tab is closed where there were pending changes that the user said to discard. Here's what the wrong behavior looks like:
![viper_ide_changed_file_bug](https://github.com/user-attachments/assets/2e50ca12-8f9c-4c1e-af43-093fb3251d19)

And here's after the fix:
![viper_ide_changed_file_fix](https://github.com/user-attachments/assets/6e21988e-5453-466b-9fda-b766c42a2c4c)
