### PR TITLE
Implement settings save/load to local storage

### DIFF
--- a/src/ViperIDE.html
+++ b/src/ViperIDE.html
@@ -134,7 +134,7 @@
                         <label for="zoom">Zoom:</label>
                         <select id="zoom">
                             <option value="0.80">80%</option>
-                            <option value="1.00">100%</option>
+                            <option value="1.00" selected>100%</option>
                             <option value="1.10">110%</option>
                             <option value="1.25">125%</option>
                             <option value="1.50">150%</option>

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,0 +1,121 @@
+import { QID } from './utils.js'
+
+
+const settingsElement = QID("menu-settings")
+let callbacks = new Map()
+let settings = _loadSettings()
+
+/**
+ *
+ * @param {string} setting The name of the setting to query
+ * @returns {boolean} Returns the value of the setting if found, else undefined
+ */
+export function getSetting(setting) {
+    return settings[setting]
+}
+
+
+/**
+ *
+ * @param {string} setting The name of the setting to update
+ * @param {string|boolean} newValue The new value to set the setting to (string for dropdowns, boolean for checkboxes)
+ */
+export function updateSetting(setting, newValue) {
+    // set the DOM
+    const settingElement = settingsElement.querySelector(`#${setting}`)
+    if (settingElement.tagName == "SELECT") {
+        settingElement.value = newValue
+    } else if (settingElement.type == "checkbox") {
+        settingElement.checked = newValue
+    } else {
+        console.error(`Element is not <select> or <input type="checkbox">: ${settingElement}`)
+    }
+
+    // set our local cache
+    settings[setting] = newValue
+
+    // inform any subscribers
+    _notify(setting, newValue)
+
+    // persist to local storage
+    _persistSettings(settings)
+}
+
+
+/**
+ *
+ * @param {string} setting The name of the setting to set a callback for
+ * @param {function(string):void} callback A callback function that will receive the new value of the setting
+ */
+export function onSettingChange(setting, callback) {
+    if (!callbacks.has(setting)) {
+        callbacks.set(setting, [])
+    }
+    callbacks.get(setting).push(callback)
+}
+
+
+settingsElement.addEventListener("change", (event) => {
+    settings = _persistSettings()
+    _notify(event.target.id, settings[event.target.id])
+})
+
+
+function _loadSettings() {
+    // get settings from either localstorage or read from the DOM (and populate local storage)
+    let loadedSettings = JSON.parse(localStorage.getItem("settings"))
+    if (!loadedSettings) {
+        _persistSettings()
+        loadedSettings = JSON.parse(localStorage.getItem("settings"))
+    }
+
+    function _setLoadedValue(setting, loadedValue, setter) {
+        // if we loaded nothing, then do nothing
+        if (loadedValue == undefined) {
+            return
+        }
+
+        // set the loaded value to the DOM
+        setter(loadedValue)
+
+        // notify any code that might need to know about what we loaded
+        _notify(setting, loadedValue)
+    }
+
+    // loop over all DOM settings elements and load them with the value from local storage
+    settingsElement.querySelectorAll("input[type='checkbox']").forEach(element => {
+        _setLoadedValue(element.id, loadedSettings[element.id], (value) => element.checked = value)
+    })
+    settingsElement.querySelectorAll("select").forEach(element => {
+        _setLoadedValue(element.id, loadedSettings[element.id], (value) => element.value = value)
+    })
+
+    return loadedSettings
+}
+
+
+function _persistSettings(newSettings = undefined) {
+    if (!newSettings) {
+        // nothing passed into us, so lets read from the DOM and persist that
+        newSettings = new Object()
+        settingsElement.querySelectorAll("input[type='checkbox']").forEach(element => {
+            newSettings[element.id] = element.checked
+        })
+        settingsElement.querySelectorAll("select").forEach(element => {
+            newSettings[element.id] = element.value
+        })
+    }
+
+    localStorage.setItem("settings", JSON.stringify(newSettings))
+    return newSettings
+}
+
+
+function _notify(setting, newValue) {
+    // If there are any callbacks for this setting update, then let's call them
+    if (callbacks.has(setting)) {
+        for (let callback of callbacks.get(setting)) {
+            callback(newValue)
+        }
+    }
+}

--- a/src/settings.js
+++ b/src/settings.js
@@ -69,14 +69,16 @@ function _loadSettings() {
         loadedSettings = JSON.parse(localStorage.getItem("settings"))
     }
 
-    function _setLoadedValue(setting, loadedValue, setter) {
-        // if we loaded nothing, then do nothing
-        if (loadedValue == undefined) {
-            return
+    function _setLoadedValue(setting, loadedValue, domValue, setter) {
+        // if we loaded nothing, then don't try to set the DOM (perhaps a brand new setting and
+        // therefore should use the default)
+        if (loadedValue != undefined) {
+            // set the loaded value to the DOM
+            setter(loadedValue)
+        } else {
+            loadedSettings[setting] = domValue
+            loadedValue = domValue
         }
-
-        // set the loaded value to the DOM
-        setter(loadedValue)
 
         // notify any code that might need to know about what we loaded
         _notify(setting, loadedValue)
@@ -84,10 +86,10 @@ function _loadSettings() {
 
     // loop over all DOM settings elements and load them with the value from local storage
     settingsElement.querySelectorAll("input[type='checkbox']").forEach(element => {
-        _setLoadedValue(element.id, loadedSettings[element.id], (value) => element.checked = value)
+        _setLoadedValue(element.id, loadedSettings[element.id], element.checked, (value) => element.checked = value)
     })
     settingsElement.querySelectorAll("select").forEach(element => {
-        _setLoadedValue(element.id, loadedSettings[element.id], (value) => element.value = value)
+        _setLoadedValue(element.id, loadedSettings[element.id], element.value, (value) => element.value = value)
     })
 
     return loadedSettings


### PR DESCRIPTION
This change implements settings save and load to the browser's local storage (request from vshymanskyy/ViperIDE#25). It also implements some helper getter/setter functions for using in other parts of the code without those other parts needing to be aware of how the settings work (e.g. needing to know to query the DOM). And it allows for setting up callbacks to listen for setting changes.

The settings are stored as a single serialized JSON blob in the storage. This made it a bit easier to load and save non-string values. It's maybe a little more difficult to reset or change a single setting in the dev tools, but I thought the trade-off was worth it.

![image](https://github.com/user-attachments/assets/79b03919-3d35-4878-b437-8557966c352c)
